### PR TITLE
Add a third direction to view transitions

### DIFF
--- a/src/components/ContentLink.astro
+++ b/src/components/ContentLink.astro
@@ -20,6 +20,7 @@ const {
 <a
   href={`/${collectionSlug || content.collection}/${content.slug}`}
   class={className}
+  data-direction="content"
   {...attributes}
 >
   {linkText || <slot />}

--- a/src/components/SharedHead.astro
+++ b/src/components/SharedHead.astro
@@ -16,3 +16,10 @@ import '@fontsource/atkinson-hyperlegible/700.css'
   <Theme />
   <ViewTransitions />
 </head>
+
+<script>
+  document.addEventListener('astro:before-preparation', (event) => {
+    event.direction =
+      (event.sourceElement as HTMLElement)?.dataset.direction || 'forward'
+  })
+</script>

--- a/src/components/SharedHead.astro
+++ b/src/components/SharedHead.astro
@@ -19,7 +19,20 @@ import '@fontsource/atkinson-hyperlegible/700.css'
 
 <script>
   document.addEventListener('astro:before-preparation', (event) => {
-    event.direction =
-      (event.sourceElement as HTMLElement)?.dataset.direction || 'forward'
+    const dir = (event.sourceElement as HTMLElement)?.dataset.direction
+    if (dir) {
+      history.replaceState({ ...history.state, direction: dir }, '')
+      event.direction = dir
+    } else {
+      const savedDir = history.state?.direction
+      if (savedDir) {
+        event.direction =
+          event.direction === 'back'
+            ? savedDir === 'back'
+              ? 'forward'
+              : 'back'
+            : savedDir
+      }
+    }
   })
 </script>

--- a/src/components/Theme.astro
+++ b/src/components/Theme.astro
@@ -1,9 +1,3 @@
----
-import ThemeSwitcher from './ThemeSwitcher.svelte'
----
-
-<ThemeSwitcher client:only="svelte" />
-
 <!-- is:inline is necessary because this script needs to set the data attribute before any CSS is loaded to prevent FOUC -->
 <script is:inline>
   const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')

--- a/src/components/Theme.astro
+++ b/src/components/Theme.astro
@@ -1,3 +1,9 @@
+---
+import ThemeSwitcher from './ThemeSwitcher.svelte'
+---
+
+<ThemeSwitcher client:only="svelte" />
+
 <!-- is:inline is necessary because this script needs to set the data attribute before any CSS is loaded to prevent FOUC -->
 <script is:inline>
   const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -3,7 +3,6 @@ import '@styles/global.css'
 import '@styles/view-transition.css'
 import SharedHead from '@components/SharedHead.astro'
 import GrainyBackground from '@components/GrainyBackground.astro'
-import ThemeSwitcher from '@components/ThemeSwitcher.svelte'
 ---
 
 <!doctype html>
@@ -12,7 +11,6 @@ import ThemeSwitcher from '@components/ThemeSwitcher.svelte'
     <slot name="head" />
   </SharedHead>
   <body>
-    <ThemeSwitcher client:only="svelte" />
     <slot />
     <GrainyBackground />
   </body>

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -3,6 +3,7 @@ import '@styles/global.css'
 import '@styles/view-transition.css'
 import SharedHead from '@components/SharedHead.astro'
 import GrainyBackground from '@components/GrainyBackground.astro'
+import ThemeSwitcher from '@components/ThemeSwitcher.svelte'
 ---
 
 <!doctype html>
@@ -11,6 +12,7 @@ import GrainyBackground from '@components/GrainyBackground.astro'
     <slot name="head" />
   </SharedHead>
   <body>
+    <ThemeSwitcher client:only="svelte" />
     <slot />
     <GrainyBackground />
   </body>

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -1,16 +1,12 @@
 ---
 import '@styles/global.css'
+import '@styles/view-transition.css'
 import SharedHead from '@components/SharedHead.astro'
 import GrainyBackground from '@components/GrainyBackground.astro'
 ---
 
 <!doctype html>
-<html
-  lang="en"
-  data-theme="light"
-  transition:name="root"
-  transition:animate="none"
->
+<html lang="en" data-theme="light">
   <SharedHead>
     <slot name="head" />
   </SharedHead>

--- a/src/pages/photos/[slug].astro
+++ b/src/pages/photos/[slug].astro
@@ -82,7 +82,7 @@ export async function getStaticPaths() {
                 as="a"
                 size="small"
                 href={`/photos/${previousPhotoSlug}`}
-                data-direction="previous"
+                data-direction="back"
               >
                 <Icon name="ri:skip-left-fill" /> Previous
               </Button>
@@ -95,7 +95,7 @@ export async function getStaticPaths() {
                 as="a"
                 size="small"
                 href={`/photos/${nextPhotoSlug}`}
-                data-direction="next"
+                data-direction="forward"
               >
                 Next <Icon name="ri:skip-right-fill" />
               </Button>

--- a/src/pages/photos/[slug].astro
+++ b/src/pages/photos/[slug].astro
@@ -42,21 +42,6 @@ export async function getStaticPaths() {
 }
 ---
 
-<script is:inline>
-  document.addEventListener('astro:before-preparation', (event) => {
-    const button = event.sourceElement
-
-    if ('direction' in button?.dataset) {
-      if (button.dataset.direction === 'next') {
-        event.direction = 'forward'
-      }
-      if (button.dataset.direction === 'previous') {
-        event.direction = 'back'
-      }
-    }
-  })
-</script>
-
 <AppLayout>
   <SEOTags
     slot="head"
@@ -76,7 +61,6 @@ export async function getStaticPaths() {
           quality={70}
           widths={[400, 800, orientation === 'landscape' ? 920 * 2 : 800 * 2]}
           transition:name={`photo-${photo.id}`}
-          transition:animate="slide"
         />
       </div>
     </div>
@@ -131,6 +115,12 @@ export async function getStaticPaths() {
 <style lang="scss" define:vars={{ 'aspect-ratio': aspectRatio }}>
   @use '@styles/mixins';
 
+  main.prose {
+    view-transition-name: photo-prose;
+    h1 {
+      view-transition-name: photo-title;
+    }
+  }
   .photo-page-layout {
     display: grid;
     min-height: 100dvh;

--- a/src/styles/view-transition.css
+++ b/src/styles/view-transition.css
@@ -7,7 +7,7 @@
  * Use * as we do not know the names.
  * view-transition-class would also work nice here but requires level 2 view transition API
  */
-:root[data-astro-transition='next'] {
+:root[data-astro-transition='forward'] {
   &::view-transition-old(*) {
     animation: 0.25s ease-in reverse both photoFromLeft;
   }
@@ -15,7 +15,7 @@
     animation: 0.5s 0.1s ease-in-out both photoFromRight;
   }
 }
-:root[data-astro-transition='previous'] {
+:root[data-astro-transition='back'] {
   &::view-transition-old(*) {
     animation: 0.3s ease-in reverse both photoFromRight;
   }

--- a/src/styles/view-transition.css
+++ b/src/styles/view-transition.css
@@ -1,0 +1,84 @@
+/* no root group */
+:root {
+  view-transition-name: none;
+}
+
+/* Slide photos from the sides.
+ * Use * as we do not know the names.
+ * view-transition-class would also work nice here but requires level 2 view transition API
+ */
+:root[data-astro-transition='next'] {
+  &::view-transition-old(*) {
+    animation: 0.25s ease-in reverse both photoFromLeft;
+  }
+  &::view-transition-new(*) {
+    animation: 0.5s 0.1s ease-in-out both photoFromRight;
+  }
+}
+:root[data-astro-transition='previous'] {
+  &::view-transition-old(*) {
+    animation: 0.3s ease-in reverse both photoFromRight;
+  }
+  &::view-transition-new(*) {
+    animation: 0.4s 0.1s ease-in-out both photoFromLeft;
+  }
+}
+
+/* restore browser defaults for prose. Not necessary when using class instead of star above.*/
+:root[data-astro-transition]::view-transition-old(photo-prose),
+:root[data-astro-transition]::view-transition-old(photo-title) {
+  animation:
+    0.5s ease both -ua-view-transition-fade-out,
+    -ua-mix-blend-mode-plus-lighter;
+}
+:root[data-astro-transition]::view-transition-new(photo-prose),
+:root[data-astro-transition]::view-transition-new(photo-title) {
+  animation:
+    0.5s ease -ua-view-transition-fade-in,
+    -ua-mix-blend-mode-plus-lighter;
+}
+
+/* Or as an alternative to restoring: skip cross-fade */
+:root[data-astro-transition]::view-transition-old(photo-prose),
+:root[data-astro-transition]::view-transition-old(photo-title) {
+  display: none;
+}
+:root[data-astro-transition]::view-transition-new(photo-prose),
+:root[data-astro-transition]::view-transition-new(photo-title) {
+  animation: none;
+}
+
+/* Make it a bit more interesting */
+::view-transition-group(photo-prose) {
+  animation-duration: 0.3s;
+  animation-delay: 0.2s;
+}
+
+@keyframes photoFromRight {
+  0% {
+    opacity: 0;
+    transform: scale(1) translateX(200px);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateX(0);
+  }
+}
+@keyframes photoFromLeft {
+  0% {
+    opacity: 0;
+    transform: scale(1) translateX(-200px);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateX(0);
+  }
+}


### PR DESCRIPTION
Hey Cassidy, see my suggestions for the third direction:

- Added a new direction called "content" alongside "previous" and "next" and set it in `ContentLink.astro` like you did for the navigation buttons.
- Moved the `before-preparation` event listener from `[slug].astro` to `SharedHead.astro` so it's also available on the gallery page.
- Removed `transition:animate` from :root and photo. They work well for simple forward/back animations but were getting in the way here.
- Created a global CSS file for view-transition styles to ensure they're available on all pages, see https://vtbag.dev/tips/css/