### PR TITLE
Move ThemeSwitcher island to the `<body>` as it otherwise closes the `<head>` and leads to FOUC

### DIFF
--- a/src/components/Theme.astro
+++ b/src/components/Theme.astro
@@ -1,9 +1,3 @@
----
-import ThemeSwitcher from './ThemeSwitcher.svelte'
----
-
-<ThemeSwitcher client:only="svelte" />
-
 <!-- is:inline is necessary because this script needs to set the data attribute before any CSS is loaded to prevent FOUC -->
 <script is:inline>
   const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -2,6 +2,7 @@
 import '@styles/global.css'
 import SharedHead from '@components/SharedHead.astro'
 import GrainyBackground from '@components/GrainyBackground.astro'
+import ThemeSwitcher from '@components/ThemeSwitcher.svelte'
 ---
 
 <!DOCTYPE html>
@@ -10,6 +11,7 @@ import GrainyBackground from '@components/GrainyBackground.astro'
     <slot name="head" />
   </SharedHead>
   <body>
+    <ThemeSwitcher client:only="svelte" />
     <slot />
     <GrainyBackground />
   </body>


### PR DESCRIPTION
I noticed that with a dark theme, you pages had a flash of white during transitions.
The reason is that you include a `client:only` island into via the SharedHead.
The islands ends your `<head>` element and everything after it is forced to the `<body>`, especially the inline script in `Theme.astro` that has to be in the `<head>` to prevent FOUC.
